### PR TITLE
Use standard method for BS12 status

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ else:
         "Persistence Station 13": ["Persistence Station", "persistence"],
         "Apollo Gaming": ["Apollo Gaming","apollo"],
         "Lebensraum Alpha": ["Lebensraum Alpha", "ss13"],
-        "Baystation 12": ["Baystation 12", "bs12", "https://baystation12.net/status.dat", 80, "http"],
+        "Baystation 12": ["Baystation 12", "bs12", "play.baystation12.net", 8000, "fetch"],
         "FTL13": ["FTL13", "ftl13", "ftl13.com", 7777, "fetch"],
         "Tool Box Station": ["Toolbox Station", "toolbox"],
         "Pressurized Roleplay": ["Pressurized Roleplay", "pressure"],


### PR DESCRIPTION
Untested, but should work.

`status.dat` is old, mostly unused, and mangles the map name (you end up with `SEV+Torch` instead of `SEV Torch`).

I think the HTTP code is only used by this server, so it might be able to be removed? Not sure, easy enough to make that change if you want it.