### PR TITLE
Enriches Hippie presence

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ servers = {
     "BeeStation 13": ["BeeStation", "beestation", "198.58.107.171", 3333, "fetch"],
     "ss13": ["Unknown Server", "ss13"],
     "Oracle Station | Medium RP": ["Oracle Station", "oraclestation"], #"byond.oraclestation.com", 5000
-    "Hippie Station": ["Hippie Station", "hippiestation"],
+    "Hippie Station": ["Hippie Station", "hippiestation", "62.210.11.24", 1337, "fetch"],
     "/tg/Station Bagil": ["Station Bagil", "tgstation", "bagil.aws.tgstation13.org", 2337, "fetch"],
     "/tg/Station Sybil": ["Station Sybil", "tgstation", "sybil.aws.tgstation13.org", 1337, "fetch"],
     "/tg/Station Terry": ["Station Terry", "tgstation", "terry.tgstation13.org", 3337, "fetch"],

--- a/main.py
+++ b/main.py
@@ -88,13 +88,13 @@ else:
                     if server[0] in ["Baystation 12"]:
                         details = status["map"]+" | "+str(status["players"])+" players"
 
-                    elif server[0] in ["Goonstation #2","Goonstation RP #1", "BeeStation", "FTL13", "Station Bagil", "Station Terry", "Station Sybil", "Citadel Station"]:
+                    elif server[0] in ["Goonstation #2","Goonstation RP #1", "Hippie Station", "BeeStation", "FTL13", "Station Bagil", "Station Terry", "Station Sybil", "Citadel Station"]:
                         details = status["map_name"]+" | "+str(status["players"])+" players"
 
                     if server[0] in ["Goonstation #2","Goonstation RP #1"]:
                         rp.set_activity(state=server[0],details=details,large_text=server[0],large_image=server[1], start=int(time.time())-int(status["elapsed"]))
 
-                    elif server[0] in ["BeeStation", "FTL13", "Station Bagil", "Station Terry", "Station Sybil", "Citadel Station"]:
+                    elif server[0] in ["Hippie Station", "BeeStation", "FTL13", "Station Bagil", "Station Terry", "Station Sybil", "Citadel Station"]:
                         rp.set_activity(state=server[0],details=details,large_text=server[0],large_image=server[1], start=int(time.time())-int(status["round_duration"]))
 
 


### PR DESCRIPTION
Since we're a fork of /tg/, we can also display players, round time and such. I didn't add the compiled exe, I assume you want to make it yourself for security reasons. I am not totally sure what "fetch" is for in the config, but considering /tg/ has it, I assumed we should too. Tell me if I missed anything.